### PR TITLE
Complete spec for Html console command

### DIFF
--- a/dep-graph-releaser-runner/src/test/kotlin/ch/loewenfels/depgraph/runner/console/HtmlSpec.kt
+++ b/dep-graph-releaser-runner/src/test/kotlin/ch/loewenfels/depgraph/runner/console/HtmlSpec.kt
@@ -1,15 +1,29 @@
 package ch.loewenfels.depgraph.runner.console
 
 import ch.loewenfels.depgraph.runner.commands.Html
+import ch.tutteli.atrium.api.cc.en_GB.contains
+import ch.tutteli.atrium.api.cc.en_GB.message
+import ch.tutteli.atrium.api.cc.en_GB.toThrow
+import ch.tutteli.atrium.expect
 import ch.tutteli.spek.extensions.TempFolder
 import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.include
 
 class HtmlSpec : Spek({
     include(HtmlCommandSpec)
 
-    //TODO write spec for wrong non-existing directory
-    //given("non-existing directory"){}
+    given("non-existing directory") {
+        val expectedOutputDirectory = "myOutDir"
+        val errMsg = "The given output directory in which the resulting HTML file (and resources) shall be created does not exist"
+        val inputArgs = arrayOf("projectName",expectedOutputDirectory)
+        it("throws an error, mentioning $errMsg") {
+            expect {
+                Html.execute(inputArgs, errorHandler)
+            }.toThrow<IllegalStateException> { message { contains(errMsg, expectedOutputDirectory) } }
+        }
+    }
 
 }) {
     object HtmlCommandSpec : CommandSpec(


### PR DESCRIPTION
Html throws an exception if a non-existing
output directory is specified