### PR TITLE
Reword button 're-trigger failed jobs' to 'resume ProcessName'

### DIFF
--- a/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/components/Menu.kt
+++ b/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/components/Menu.kt
@@ -255,7 +255,7 @@ class Menu(private val eventManager: EventManager) {
                     |Please report a bug at $GITHUB_NEW_ISSUE in case a job failed due to an error in dep-graph-releaser.
                     """.trimMargin()
                 )
-                buttonText.innerText = "Re-trigger failed Jobs"
+                buttonText.innerText = "Resume '$processName'"
                 button.title = "Continue with the process '$processName' by re-processing previously failed projects."
             }
         }


### PR DESCRIPTION
Resons:
- We might not re-trigger a Job at all if we previously have set the command to succeeded and with issue #66 we might also only re-poll the command when it is not set to succeeded
- We should not talk about Jobs but either Command or Project. Yet, we think it's better if the name still contains the name of the process. So, e.g. Resume 'Dry Run'.

- resolves #67