### PR TITLE
Support empty jobMapping

### DIFF
--- a/api/dep-graph-releaser-api-common/src/main/kotlin/ch/loewenfels/depgraph/configParser.kt
+++ b/api/dep-graph-releaser-api-common/src/main/kotlin/ch/loewenfels/depgraph/configParser.kt
@@ -10,7 +10,7 @@ fun parseJobMapping(releasePlan: ReleasePlan): Map<String, String> =
 
 fun parseJobMapping(mapping: String): Map<String, String> {
     //TODO #14 do not associate immediately but first map to list and check if there are duplicates
-    return mapping.trim().split("\n").associate { pair ->
+    return mapping.trim().split("\n").filter { it.isNotEmpty() }.associate { pair ->
         val index = pair.indexOf('=')
         require(index > 0) {
             "At least one mapping has no groupId and artifactId defined.\njobMapping: $mapping"


### PR DESCRIPTION
If no jobMapping is provided at all, it should not throw (resolves #87).

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/loewenfels/dep-graph-releaser/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.