### PR TITLE
Use OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
 # junit5 requires java 8
-- oraclejdk8
-- oraclejdk9
+- openjdk8
+- openjdk9
 
 addons:
     sonarcloud:


### PR DESCRIPTION
Installation of OracleJDK is now failing because Oracle's licensing has
changed and the JDK cannot be downloaded from Oracle any longer without
logging in.

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/loewenfels/dep-graph-releaser/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.