### PR TITLE
Check for duplicates in job-mapping

### DIFF
--- a/api/dep-graph-releaser-api-common/src/main/kotlin/ch/loewenfels/depgraph/configParser.kt
+++ b/api/dep-graph-releaser-api-common/src/main/kotlin/ch/loewenfels/depgraph/configParser.kt
@@ -9,8 +9,8 @@ fun parseJobMapping(releasePlan: ReleasePlan): Map<String, String> =
 
 
 fun parseJobMapping(mapping: String): Map<String, String> {
-    //TODO #14 do not associate immediately but first map to list and check if there are duplicates
-    return mapping.trim().split("\n").filter { it.isNotEmpty() }.associate { pair ->
+    val filteredMapping = mapping.trim().split("\n").filter { it.isNotEmpty() }
+    return filteredMapping.associate { pair ->
         val index = pair.indexOf('=')
         require(index > 0) {
             "At least one mapping has no groupId and artifactId defined.\njobMapping: $mapping"
@@ -24,7 +24,9 @@ fun parseJobMapping(mapping: String): Map<String, String> {
             "At least one groupId and artifactId is erroneous, has no job name defined.\njobMapping: $mapping"
         }
         groupIdAndArtifactId to jobName
-    }
+    }.also { resultMap -> require(resultMap.size == filteredMapping.size) {
+        "At least one jobMapping is a duplicate.\njobMapping: $mapping"
+    } }
 }
 
 fun parseRemoteRegex(releasePlan: ReleasePlan) =

--- a/dep-graph-releaser-runner/src/test/kotlin/ch/loewenfels/depgraph/runner/console/JsonSpec.kt
+++ b/dep-graph-releaser-runner/src/test/kotlin/ch/loewenfels/depgraph/runner/console/JsonSpec.kt
@@ -132,7 +132,7 @@ class JsonSpec : Spek({
                     val args = createArgs(tempFolder, "com.example:a;com.example:b", ".*#maven#rel;nextDev;add", "job=job2")
                     expect {
                         dispatch(args, errorHandler, listOf(Json))
-                    }.toThrow<IllegalArgumentException> {}
+                    }.toThrow<IllegalArgumentException> { messageContains("At least one groupId and artifactId is erroneous, does not contain a `:`.") }
                 }
             }
 
@@ -141,7 +141,7 @@ class JsonSpec : Spek({
                     val args = createArgs(tempFolder, "com.example:a;com.example:b", ".*#maven#rel;nextDev;add", "com:job,job2")
                     expect {
                         dispatch(args, errorHandler, listOf(Json))
-                    }.toThrow<IllegalArgumentException> {}
+                    }.toThrow<IllegalArgumentException> { messageContains("At least one mapping has no groupId and artifactId defined.") }
                 }
             }
 
@@ -150,7 +150,7 @@ class JsonSpec : Spek({
                     val args = createArgs(tempFolder, "com.example:a;com.example:b", ".*#maven#rel;nextDev;add", "com:job=job2\ncom:job2,job3")
                     expect {
                         dispatch(args, errorHandler, listOf(Json))
-                    }.toThrow<IllegalArgumentException> {}
+                    }.toThrow<IllegalArgumentException> { messageContains("At least one mapping has no groupId and artifactId defined.") }
                 }
             }
 
@@ -159,7 +159,25 @@ class JsonSpec : Spek({
                     val args = createArgs(tempFolder, "com.example:a;com.example:b", ".*#maven#rel;nextDev;add", "com:job=job2\n\ncom:job2,job3")
                     expect {
                         dispatch(args, errorHandler, listOf(Json))
-                    }.toThrow<IllegalArgumentException> {}
+                    }.toThrow<IllegalArgumentException> { messageContains("At least one mapping has no groupId and artifactId defined.") }
+                }
+            }
+
+            describe("no job name defined") {
+                it("throws IllegalArgumentException") {
+                    val args = createArgs(tempFolder, "com.example:a;com.example:b", ".*#maven#rel;nextDev;add", "com:job=job1\ncom:job2=")
+                    expect {
+                        dispatch(args, errorHandler, listOf(Json))
+                    }.toThrow<IllegalArgumentException> { messageContains("At least one groupId and artifactId is erroneous, has no job name defined.") }
+                }
+            }
+
+            describe("job duplicate") {
+                it("throws IllegalArgumentException") {
+                    val args = createArgs(tempFolder, "com.example:a;com.example:b", ".*#maven#rel;nextDev;add", "com:job=job1\ncom:job=job2")
+                    expect {
+                        dispatch(args, errorHandler, listOf(Json))
+                    }.toThrow<IllegalArgumentException> { messageContains("At least one jobMapping is a duplicate.") }
                 }
             }
         }


### PR DESCRIPTION
If there is a duplicate in job-mapping, an error should be thrown when the
Json console command is used.
Spec for job duplicate and no defined job name is added, and all the job
mapping specs assert the message now.

- resolves #14

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/loewenfels/dep-graph-releaser/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.