### PR TITLE
Ignore synthetic root in toolbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
         sonar-scanner \
             -Dsonar.projectKey=loewenfels_dep-graph-releaser \
             -Dsonar.projectVersion=1.3.0-SNAPSHOT \
+            -Dsonar.scm.disabled=true \
             -Dsonar.java.coveragePlugin=jacoco \
             -Dsonar.kotlin.detekt.reportPaths=build/reports/detekt/detekt.xml \
             -Dsonar.sources="\

--- a/api/dep-graph-releaser-api-common/src/main/kotlin/ch/loewenfels/depgraph/export.kt
+++ b/api/dep-graph-releaser-api-common/src/main/kotlin/ch/loewenfels/depgraph/export.kt
@@ -99,9 +99,12 @@ private fun projectsWithoutSubmodulesAndExcluded(
     excludeRegex: Regex
 ): Sequence<Project> = sequence
     .filter { !it.isSubmodule }
+    .filter { it.id.identifier != SYNTHETIC_ROOT }
     .filter { !excludeRegex.matches(it.relativePath) }
 
 fun Project.turnIntoGitRepoUrl(
     relativePathTransformerRegex: Regex,
     relativePathTransformerReplacement: String
 ) = relativePathTransformerRegex.replace(relativePath, relativePathTransformerReplacement)
+
+private const val SYNTHETIC_ROOT = "ch.loewenfels:synthetic-root"

--- a/api/dep-graph-releaser-api-jvm/src/test/kotlin/ch/loewenfels/depgraph/ExportSpec.kt
+++ b/api/dep-graph-releaser-api-jvm/src/test/kotlin/ch/loewenfels/depgraph/ExportSpec.kt
@@ -1,0 +1,72 @@
+package ch.loewenfels.depgraph
+
+import ch.loewenfels.depgraph.data.Project
+import ch.loewenfels.depgraph.data.ProjectId
+import ch.loewenfels.depgraph.data.maven.MavenProjectId
+import ch.tutteli.atrium.api.cc.en_GB.containsNot
+import ch.tutteli.atrium.assert
+import ch.tutteli.atrium.createReleasePlanWithDefaults
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class ExportSpec : Spek({
+
+    fun createProject(
+        id: ProjectId,
+        isSubmodule: Boolean,
+        currentVersion: String,
+        releaseVersion: String, level: Int
+    ) = Project(id, isSubmodule, currentVersion, releaseVersion, level, listOf(), "")
+
+    describe("list of dependents") {
+
+        given("release of both project A and project B") {
+
+            val rootProjectId = MavenProjectId("com.example", "parent-parent")
+            val rootProject = createProject(rootProjectId, false, "1.1.0-SNAPSHOT", "1.2.0", 0)
+
+            val syntheticRootId = MavenProjectId("ch.loewenfels", "synthetic-root")
+            val syntheticRoot = createProject(syntheticRootId, false, "0.0.0-SNAPSHOT", "0.0.0", 1)
+
+            val projectInterfaceId = MavenProjectId("com.example", "interface")
+            val projectInterface = createProject(projectInterfaceId, false, "2.0", "3.0", 2)
+
+            val projectAnnotationsId = MavenProjectId("com.example", "annotations")
+            val projectAnnotations = createProject(projectAnnotationsId, false, "4.0", "4.1", 3)
+
+            val projectNotifierId = MavenProjectId("com.example", "notifier")
+            val projectNotifier = createProject(projectNotifierId, false, "5.0", "5.1", 4)
+
+            val dependents = mapOf<ProjectId, Set<MavenProjectId>>(
+                rootProjectId to setOf(syntheticRootId),
+                syntheticRootId to setOf(projectInterfaceId, projectAnnotationsId, projectNotifierId),
+                projectInterfaceId to setOf(projectAnnotationsId, projectNotifierId),
+                projectAnnotationsId to setOf(projectNotifierId),
+                projectNotifierId to setOf()
+            )
+            val releasePlan = createReleasePlanWithDefaults(
+                "releaseId",
+                rootProjectId,
+                mapOf(
+                    rootProjectId to rootProject,
+                    syntheticRootId to syntheticRoot,
+                    projectInterfaceId to projectInterface,
+                    projectAnnotationsId to projectAnnotations,
+                    projectNotifierId to projectNotifier
+                ),
+                mapOf(),
+                dependents
+            )
+
+            it("does not return synthetic root project") {
+                val list = generateListOfDependentsWithoutSubmoduleAndExcluded(
+                    releasePlan,
+                    Regex(".*# ")
+                )
+                assert(list).containsNot("ch.loewenfels:synthetic-root")
+            }
+        }
+    }
+})

--- a/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/ContentContainer.kt
+++ b/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/ContentContainer.kt
@@ -2,8 +2,6 @@ package ch.loewenfels.depgraph.gui
 
 import ch.loewenfels.depgraph.ConfigKey
 import ch.loewenfels.depgraph.data.ReleasePlan
-import ch.loewenfels.depgraph.data.maven.MavenProjectId
-import ch.loewenfels.depgraph.data.maven.syntheticRoot
 import ch.loewenfels.depgraph.gui.components.*
 import ch.loewenfels.depgraph.gui.jobexecution.ProcessStarter
 import ch.loewenfels.depgraph.gui.serialization.ModifiableState

--- a/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/ContentContainer.kt
+++ b/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/ContentContainer.kt
@@ -15,19 +15,11 @@ import kotlin.browser.document
 class ContentContainer(modifiableState: ModifiableState, private val menu: Menu, processStarter: ProcessStarter?) {
     init {
         val releasePlan = modifiableState.releasePlan
-        val htmlTitle = getHtmlTitle(releasePlan)
+        val htmlTitle = menu.getProjectTitle(releasePlan)
         document.title = "DGR $htmlTitle"
         Messages(releasePlan)
         setUpConfig(releasePlan)
         Pipeline(modifiableState, menu, processStarter)
-    }
-
-    private fun getHtmlTitle(releasePlan: ReleasePlan): String {
-        val rootProjectId = releasePlan.rootProjectId
-        if (rootProjectId == syntheticRoot) return releasePlan.getDependents(releasePlan.rootProjectId).joinToString(", ") {
-                (it as? MavenProjectId)?.artifactId ?: it.identifier
-            }
-        return (rootProjectId as? MavenProjectId)?.artifactId ?: rootProjectId.identifier
     }
 
     private fun setUpConfig(releasePlan: ReleasePlan) {

--- a/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/components/Menu.kt
+++ b/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/components/Menu.kt
@@ -1,8 +1,11 @@
 package ch.loewenfels.depgraph.gui.components
 
 import ch.loewenfels.depgraph.ConfigKey
+import ch.loewenfels.depgraph.data.ReleasePlan
 import ch.loewenfels.depgraph.data.ReleaseState
 import ch.loewenfels.depgraph.data.TypeOfRun
+import ch.loewenfels.depgraph.data.maven.MavenProjectId
+import ch.loewenfels.depgraph.data.maven.syntheticRoot
 import ch.loewenfels.depgraph.data.toProcessName
 import ch.loewenfels.depgraph.generateEclipsePsf
 import ch.loewenfels.depgraph.generateGitCloneCommands
@@ -182,9 +185,17 @@ class Menu(private val eventManager: EventManager) {
                 releasePlan,
                 Regex(releasePlan.getConfig(ConfigKey.RELATIVE_PATH_EXCLUDE_PROJECT_REGEX))
             )
-            val title = "The following projects are (indirect) dependents of ${releasePlan.rootProjectId.identifier}"
+            val title = "The following projects are (indirect) dependents of " + getProjectTitle(releasePlan)
             showOutput(title, list)
         }
+    }
+
+    fun getProjectTitle(releasePlan: ReleasePlan): String {
+        val rootProjectId = releasePlan.rootProjectId
+        if (rootProjectId == syntheticRoot) return releasePlan.getDependents(releasePlan.rootProjectId).joinToString(", ") {
+            (it as? MavenProjectId)?.artifactId ?: it.identifier
+        }
+        return (rootProjectId as? MavenProjectId)?.artifactId ?: rootProjectId.identifier
     }
 
     private fun initReportButtons(modifiableState: ModifiableState) {

--- a/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/components/reports.kt
+++ b/dep-graph-releaser-gui/src/main/kotlin/ch.loewenfels.depgraph/gui/components/reports.kt
@@ -15,14 +15,19 @@ internal fun generateChangelog(
     appendProjectToCsv: (StringBuilder, Project, String, String) -> Unit
 ): String {
     val sb = StringBuilder("Project;Release Version;Next Dev Version;Other Commands\n")
-    releasePlan.iterator().asSequence().filter { !it.isSubmodule }.forEach { project ->
-        val nextDevVersion = project.commands.asSequence()
+    releasePlan.iterator().asSequence()
+        .filter { !it.isSubmodule }
+        .filter { it.id.identifier != SYNTHETIC_ROOT }
+        .forEach { project ->
+            val nextDevVersion = project.commands.asSequence()
             .filterIsInstance<JenkinsNextDevReleaseCommand>()
             .first().nextDevVersion
         appendProjectToCsv(sb, project, project.releaseVersion, nextDevVersion)
     }
     return sb.toString()
 }
+
+private const val SYNTHETIC_ROOT = "ch.loewenfels:synthetic-root"
 
 internal fun appendProjectToCsvExcel(
     sb: StringBuilder,


### PR DESCRIPTION
- When releasing multiple projects, the synthetic root should be ignored
  in all commands under Tools
- Resolves #101

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/loewenfels/dep-graph-releaser/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.